### PR TITLE
Correct from list

### DIFF
--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -165,9 +165,9 @@ keys = M.keys . unpack
 {-# INLINE keys #-}
 
 -- | /O(n*log n)/. Construct a map with the supplied mappings. If the list
--- contains duplicate mappings, the later mappings take precedence.
-fromList :: (Eq k, Hashable k) => [(k,a)] -> MonoidalHashMap k a
-fromList = pack . M.fromList
+-- contains duplicate mappings, values will be merged using (mappend newVal oldVal).
+fromList :: (Eq k, Hashable k, Monoid a) => [(k,a)] -> MonoidalHashMap k a
+fromList = pack . M.fromListWith mappend
 {-# INLINE fromList #-}
 
 -- | /O(n*log n)/. Construct a map with the supplied mappings. If the list

--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -170,8 +170,8 @@ fromList :: (Eq k, Hashable k, Monoid a) => [(k,a)] -> MonoidalHashMap k a
 fromList = pack . M.fromListWith mappend
 {-# INLINE fromList #-}
 
--- | /O(n*log n)/. Construct a map with the supplied mappings. If the list
--- contains duplicate mappings, the later mappings take precedence.
+-- | /O(n*log n)/.  Return a list of this map's elements. The list is produced
+-- lazily. The order of its elements is unspecified.
 toList :: MonoidalHashMap k a -> [(k,a)]
 toList = M.toList . unpack
 {-# INLINE toList #-}
@@ -198,7 +198,8 @@ modifyDef d f k = pack
                 . unpack
 {-# INLINE modifyDef #-}
 
--- | /O(n)/. Map a function to each key of a map
+-- | /O(n)/. Map a function to each key of a map, if it will result
+-- in duplicated mappings, their values will be merged in unspecified order
 mapKeys :: (Monoid a, Hashable k, Eq k, Hashable k', Eq k')
         => (k -> k') -> MonoidalHashMap k a -> MonoidalHashMap k' a
 mapKeys f = fromList


### PR DESCRIPTION
I think it makes very little sense to have `MonoidalHashMap` with no `Monoid` in it and it's quite surprising (I have spent some hours finding it out in our system) to have `fromList` just skipping previous duplicates.