### PR TITLE
Make fromList safe by requiring Semigroup on values.

### DIFF
--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -62,6 +62,7 @@ module Data.Map.Monoidal
     , fromAscListWith
     , fromAscListWithKey
     , fromDistinctAscList
+    , fromDistinctList
     , fromList
     , fromListWith
     , fromListWithKey
@@ -477,8 +478,8 @@ toList :: forall k a. MonoidalMap k a -> [(k, a)]
 toList = coerce (M.toList :: M.Map k a -> [(k, a)])
 {-# INLINE toList #-}
 
-fromList :: forall k a. Ord k => [(k, a)] -> MonoidalMap k a
-fromList = coerce (M.fromList :: [(k, a)] -> M.Map k a)
+fromList :: forall k a. (Ord k, Semigroup a) => [(k, a)] -> MonoidalMap k a
+fromList = fromListWith (<>)
 {-# INLINE fromList #-}
 
 fromListWith :: forall k a. Ord k => (a -> a -> a) -> [(k, a)] -> MonoidalMap k a
@@ -497,8 +498,8 @@ toDescList :: forall k a. MonoidalMap k a -> [(k, a)]
 toDescList = coerce (M.toDescList :: M.Map k a -> [(k, a)])
 {-# INLINE toDescList #-}
 
-fromAscList :: forall k a. Eq k => [(k, a)] -> MonoidalMap k a
-fromAscList = coerce (M.fromAscList :: [(k, a)] -> M.Map k a)
+fromAscList :: forall k a. (Eq k, Semigroup a) => [(k, a)] -> MonoidalMap k a
+fromAscList = fromAscListWith (<>)
 {-# INLINE fromAscList #-}
 
 fromAscListWith :: forall k a. Eq k => (a -> a -> a) -> [(k, a)] -> MonoidalMap k a
@@ -512,6 +513,10 @@ fromAscListWithKey = coerce (M.fromAscListWithKey :: (k -> a -> a -> a) -> [(k, 
 fromDistinctAscList :: forall k a. [(k, a)] -> MonoidalMap k a
 fromDistinctAscList = coerce (M.fromDistinctAscList :: [(k, a)] -> M.Map k a)
 {-# INLINE fromDistinctAscList #-}
+
+fromDistinctList :: forall k a. Ord k => [(k, a)] -> MonoidalMap k a
+fromDistinctList = coerce (M.fromList :: [(k, a)] -> M.Map k a)
+{-# INLINE fromDistinctList #-}
 
 filter :: forall k a. (a -> Bool) -> MonoidalMap k a -> MonoidalMap k a
 filter = coerce (M.filter :: (a -> Bool) -> M.Map k a -> M.Map k a)

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -62,6 +62,7 @@ module Data.Map.Monoidal.Strict
     , fromAscListWith
     , fromAscListWithKey
     , fromDistinctAscList
+    , fromDistinctList
     , fromList
     , fromListWith
     , fromListWithKey
@@ -476,8 +477,8 @@ toList :: forall k a. MonoidalMap k a -> [(k, a)]
 toList = coerce (M.toList :: M.Map k a -> [(k, a)])
 {-# INLINE toList #-}
 
-fromList :: forall k a. Ord k => [(k, a)] -> MonoidalMap k a
-fromList = coerce (M.fromList :: [(k, a)] -> M.Map k a)
+fromList :: forall k a. (Ord k, Semigroup a) => [(k, a)] -> MonoidalMap k a
+fromList = fromListWith (<>)
 {-# INLINE fromList #-}
 
 fromListWith :: forall k a. Ord k => (a -> a -> a) -> [(k, a)] -> MonoidalMap k a
@@ -496,8 +497,8 @@ toDescList :: forall k a. MonoidalMap k a -> [(k, a)]
 toDescList = coerce (M.toDescList :: M.Map k a -> [(k, a)])
 {-# INLINE toDescList #-}
 
-fromAscList :: forall k a. Eq k => [(k, a)] -> MonoidalMap k a
-fromAscList = coerce (M.fromAscList :: [(k, a)] -> M.Map k a)
+fromAscList :: forall k a. (Eq k, Semigroup a) => [(k, a)] -> MonoidalMap k a
+fromAscList = fromAscListWith (<>)
 {-# INLINE fromAscList #-}
 
 fromAscListWith :: forall k a. Eq k => (a -> a -> a) -> [(k, a)] -> MonoidalMap k a
@@ -511,6 +512,10 @@ fromAscListWithKey = coerce (M.fromAscListWithKey :: (k -> a -> a -> a) -> [(k, 
 fromDistinctAscList :: forall k a. [(k, a)] -> MonoidalMap k a
 fromDistinctAscList = coerce (M.fromDistinctAscList :: [(k, a)] -> M.Map k a)
 {-# INLINE fromDistinctAscList #-}
+
+fromDistinctList :: forall k a. Ord k => [(k, a)] -> MonoidalMap k a
+fromDistinctList = coerce (M.fromList :: [(k, a)] -> M.Map k a)
+{-# INLINE fromDistinctList #-}
 
 filter :: forall k a. (a -> Bool) -> MonoidalMap k a -> MonoidalMap k a
 filter = coerce (M.filter :: (a -> Bool) -> M.Map k a -> M.Map k a)


### PR DESCRIPTION
Rename old behavior to `fromDistinctList`.

I ran into a bug that would have been caught by this change. Arguably, the main reason for using `MonoidalMap` in the first place is so that you can't just toss type-safety* under the buss like you can with `Map.fromList`. When performance is critical, you can use longer-named functions.

I can imagine debates against this change. It makes `MonoidalMap` have a *slightly* different API than `Map`. It's no longer a strict drop-in replacement. However, my counter-argument to these is that this particular change is exactly the kind of thing you'd *not* want to preserve if you merely switched an import from `import Data.Map` to `import Data.Map.Monoidal`. It would be unfortunate if `foldMap (uncurry singleton) /= fromList` where `fromList` is the de-facto "constructor" for many containers. I think with the "de-facto" part implies "safe" in that it is consistent with the container's purpose.

I could not think of a good reason to keep the old `fromAscList` as is. `fromDistinctAscList` already exists. If one is desperate, they can always `coerce` a `Map` into a `MonoidalMap`.

\* Where "type-safety" here means "not being able to do the wrong thing unintentionally".