### PR TITLE
Define Functor instance as a strict variant of `map`

### DIFF
--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -152,10 +152,14 @@ import Data.Functor.Classes
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
-    deriving (Show, Read, Functor, Eq, Ord, NFData,
+    deriving (Show, Read, Eq, Ord, NFData,
               Foldable, Traversable,
               FromJSON, ToJSON, FromJSON1, ToJSON1,
               Data, Typeable)
+
+instance Functor (MonoidalMap k) where
+  fmap f = MonoidalMap . M.map f . getMonoidalMap
+  {-# INLINE fmap #-}
 
 #if MIN_VERSION_containers(0,5,9)
 deriving instance (Ord k) => Eq1 (MonoidalMap k)

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -158,7 +158,7 @@ newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
               Data, Typeable)
 
 instance Functor (MonoidalMap k) where
-  fmap f = MonoidalMap . M.map f . getMonoidalMap
+  fmap f = coerce ((M.map :: (a -> b) -> M.Map k a -> M.Map k b) f)
   {-# INLINE fmap #-}
 
 #if MIN_VERSION_containers(0,5,9)


### PR DESCRIPTION
The `Functor` instance for `Map` is lazy. This is a common pitfall. For
those looking for strictness, `fmap` ends up introducing more laziness.
This is unavoidable in `Data.Map.Strict`, but with the `newtype` in
`Data.Map.Monoidal.Strict` we can utilize a strict `Functor` instance.

Addresses: https://github.com/bgamari/monoidal-containers/issues/31