### PR TITLE
Derive Align instances from `these` package

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -47,6 +47,7 @@ library
                        hashable >= 1.2 && < 1.3,
                        lens >=4.4 && <5,
                        newtype >=0.2 && <0.3,
-                       semigroups >= 0.18 && < 0.19
+                       semigroups >= 0.18 && < 0.19,
+                       these
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -58,11 +58,12 @@ import Data.Hashable.Lifted (Hashable1)
 #endif
 import Control.Lens
 import Control.Newtype
+import Data.Align
 
 -- | A 'HashMap' with monoidal accumulation
 newtype MonoidalHashMap k a = MonoidalHashMap { getMonoidalHashMap :: M.HashMap k a }
     deriving ( Show, Read, Functor, Eq, NFData
-             , Foldable, Traversable, Data, Typeable, Hashable
+             , Foldable, Traversable, Data, Typeable, Hashable, Align
 #if MIN_VERSION_unordered_containers(0,2,8)
              , Hashable1
 #endif

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -149,13 +149,14 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 #if MIN_VERSION_containers(0,5,9)
 import Data.Functor.Classes
 #endif
+import Data.Align
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
     deriving (Show, Read, Functor, Eq, Ord, NFData,
               Foldable, Traversable,
               FromJSON, ToJSON, FromJSON1, ToJSON1,
-              Data, Typeable)
+              Data, Typeable, Align)
 
 #if MIN_VERSION_containers(0,5,9)
 deriving instance (Ord k) => Eq1 (MonoidalMap k)

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -149,13 +149,14 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 #if MIN_VERSION_containers(0,5,9)
 import Data.Functor.Classes
 #endif
+import Data.Align
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
     deriving (Show, Read, Functor, Eq, Ord, NFData,
               Foldable, Traversable,
               FromJSON, ToJSON, FromJSON1, ToJSON1,
-              Data, Typeable)
+              Data, Typeable, Align)
 
 #if MIN_VERSION_containers(0,5,9)
 deriving instance (Ord k) => Eq1 (MonoidalMap k)


### PR DESCRIPTION
This is a simple modification to derive the `Align` typeclass for the monidal maps. This pulls in a new dependency, [`these`](http://hackage.haskell.org/package/these).