### PR TITLE
Make insert and mapKeys correspond semantically

### DIFF
--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -67,6 +67,9 @@ newtype MonoidalHashMap k a = MonoidalHashMap { getMonoidalHashMap :: M.HashMap 
 #if MIN_VERSION_unordered_containers(0,2,8)
              , Hashable1
 #endif
+#if MIN_VERSION_these(0,8,0)
+             , Semialign
+#endif
              )
 
 type instance Index (MonoidalHashMap k a) = k

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -154,10 +154,14 @@ import Data.Align
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
-    deriving (Show, Read, Functor, Eq, Ord, NFData,
-              Foldable, Traversable,
-              FromJSON, ToJSON, FromJSON1, ToJSON1,
-              Data, Typeable, Align)
+    deriving ( Show, Read, Functor, Eq, Ord, NFData
+             , Foldable, Traversable
+             , FromJSON, ToJSON, FromJSON1, ToJSON1
+             , Data, Typeable, Align
+#if MIN_VERSION_these(0,8,0)
+             , Semialign
+#endif
+             )
 
 #if MIN_VERSION_containers(0,5,9)
 deriving instance (Ord k) => Eq1 (MonoidalMap k)

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -423,14 +423,32 @@ mapAccumRWithKey :: forall k a b c. (a -> k -> b -> (a, c)) -> a -> MonoidalMap 
 mapAccumRWithKey = coerce (M.mapAccumRWithKey :: (a -> k -> b -> (a, c)) -> a -> M.Map k b -> (a, M.Map k c))
 {-# INLINE mapAccumRWithKey #-}
 
-mapKeys :: forall k1 k2 a. Ord k2 => (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
-mapKeys = coerce (M.mapKeys :: (k1 -> k2) -> M.Map k1 a -> M.Map k2 a)
+mapKeys :: forall k1 k2 a. (Ord k2, Semigroup a) => (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
+mapKeys = mapKeysWith (<>)
 {-# INLINE mapKeys #-}
 
 mapKeysWith :: forall k1 k2 a. Ord k2 => (a -> a -> a) -> (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
 mapKeysWith = coerce (M.mapKeysWith :: (a -> a -> a) -> (k1 -> k2) -> M.Map k1 a -> M.Map k2 a)
 {-# INLINE mapKeysWith #-}
 
+-- | /O(n)/.
+-- @'mapKeysMonotonic' f s == 'mapKeys' f s@, but works only when @f@
+-- is strictly increasing (both monotonic and injective).
+-- That is, for any values @x@ and @y@, if @x@ < @y@ then @f x@ < @f y@
+-- and @f@ is injective (i.e. it never maps two input keys to the same output key).
+-- /The precondition is not checked./
+-- Semi-formally, we have:
+--
+-- > and [x < y ==> f x < f y | x <- ls, y <- ls]
+-- >                     ==> mapKeysMonotonic f s == mapKeys f s
+-- >     where ls = keys s
+--
+-- This means that @f@ maps distinct original keys to distinct resulting keys.
+-- This function has better performance than 'mapKeys'.
+--
+-- > mapKeysMonotonic (\ k -> k * 2) (fromList [(5,"a"), (3,"b")]) == fromList [(6, "b"), (10, "a")]
+-- > valid (mapKeysMonotonic (\ k -> k * 2) (fromList [(5,"a"), (3,"b")])) == True
+-- > valid (mapKeysMonotonic (\ _ -> 1)     (fromList [(5,"a"), (3,"b")])) == False
 mapKeysMonotonic :: forall k1 k2 a. (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
 mapKeysMonotonic = coerce (M.mapKeysMonotonic :: (k1 -> k2) -> M.Map k1 a -> M.Map k2 a)
 {-# INLINE mapKeysMonotonic #-}

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -323,8 +323,8 @@ empty :: forall k a. MonoidalMap k a
 empty = coerce (M.empty :: M.Map k a)
 {-# INLINE empty #-}
 
-insert :: forall k a. Ord k => k -> a -> MonoidalMap k a -> MonoidalMap k a
-insert = coerce (M.insert :: k -> a -> M.Map k a -> M.Map k a)
+insert :: forall k a. (Ord k, Semigroup a) => k -> a -> MonoidalMap k a -> MonoidalMap k a
+insert = insertWith (<>)
 {-# INLINE insert #-}
 
 insertWith :: forall k a. Ord k => (a -> a -> a) -> k -> a -> MonoidalMap k a -> MonoidalMap k a

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -154,10 +154,14 @@ import Data.Align
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
-    deriving (Show, Read, Functor, Eq, Ord, NFData,
-              Foldable, Traversable,
-              FromJSON, ToJSON, FromJSON1, ToJSON1,
-              Data, Typeable, Align)
+    deriving ( Show, Read, Functor, Eq, Ord, NFData
+             , Foldable, Traversable
+             , FromJSON, ToJSON, FromJSON1, ToJSON1
+             , Data, Typeable, Align
+#if MIN_VERSION_these(0,8,0)
+             , Semialign
+#endif
+             )
 
 #if MIN_VERSION_containers(0,5,9)
 deriving instance (Ord k) => Eq1 (MonoidalMap k)

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -322,8 +322,8 @@ empty :: forall k a. MonoidalMap k a
 empty = coerce (M.empty :: M.Map k a)
 {-# INLINE empty #-}
 
-insert :: forall k a. Ord k => k -> a -> MonoidalMap k a -> MonoidalMap k a
-insert = coerce (M.insert :: k -> a -> M.Map k a -> M.Map k a)
+insert :: forall k a. (Ord k, Semigroup a) => k -> a -> MonoidalMap k a -> MonoidalMap k a
+insert = insertWith (<>)
 {-# INLINE insert #-}
 
 insertWith :: forall k a. Ord k => (a -> a -> a) -> k -> a -> MonoidalMap k a -> MonoidalMap k a

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -422,14 +422,32 @@ mapAccumRWithKey :: forall k a b c. (a -> k -> b -> (a, c)) -> a -> MonoidalMap 
 mapAccumRWithKey = coerce (M.mapAccumRWithKey :: (a -> k -> b -> (a, c)) -> a -> M.Map k b -> (a, M.Map k c))
 {-# INLINE mapAccumRWithKey #-}
 
-mapKeys :: forall k1 k2 a. Ord k2 => (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
-mapKeys = coerce (M.mapKeys :: (k1 -> k2) -> M.Map k1 a -> M.Map k2 a)
+mapKeys :: forall k1 k2 a. (Ord k2, Semigroup a) => (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
+mapKeys = mapKeysWith (<>)
 {-# INLINE mapKeys #-}
 
 mapKeysWith :: forall k1 k2 a. Ord k2 => (a -> a -> a) -> (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
 mapKeysWith = coerce (M.mapKeysWith :: (a -> a -> a) -> (k1 -> k2) -> M.Map k1 a -> M.Map k2 a)
 {-# INLINE mapKeysWith #-}
 
+-- | /O(n)/.
+-- @'mapKeysMonotonic' f s == 'mapKeys' f s@, but works only when @f@
+-- is strictly increasing (both monotonic and injective).
+-- That is, for any values @x@ and @y@, if @x@ < @y@ then @f x@ < @f y@
+-- and @f@ is injective (i.e. it never maps two input keys to the same output key).
+-- /The precondition is not checked./
+-- Semi-formally, we have:
+--
+-- > and [x < y ==> f x < f y | x <- ls, y <- ls]
+-- >                     ==> mapKeysMonotonic f s == mapKeys f s
+-- >     where ls = keys s
+--
+-- This means that @f@ maps distinct original keys to distinct resulting keys.
+-- This function has better performance than 'mapKeys'.
+--
+-- > mapKeysMonotonic (\ k -> k * 2) (fromList [(5,"a"), (3,"b")]) == fromList [(6, "b"), (10, "a")]
+-- > valid (mapKeysMonotonic (\ k -> k * 2) (fromList [(5,"a"), (3,"b")])) == True
+-- > valid (mapKeysMonotonic (\ _ -> 1)     (fromList [(5,"a"), (3,"b")])) == False
 mapKeysMonotonic :: forall k1 k2 a. (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
 mapKeysMonotonic = coerce (M.mapKeysMonotonic :: (k1 -> k2) -> M.Map k1 a -> M.Map k2 a)
 {-# INLINE mapKeysMonotonic #-}


### PR DESCRIPTION
Based on #37 so that CI works.

This makes `insert` and `mapKeys` to do the "right thing" (cc @alexfmpe).

~I'm on the fence about renaming `mapKeysMonotonic` to `mapKeysAsc`.~ I reverted that change and have pushed the question upstream: https://github.com/haskell/containers/issues/617. What I've found is that `mapKeysMonotonic` is actually incorrectly named. It doesn't support non-decreasing functions as it's name implies. It only supports *increasing* functions:

```haskell
valid (mapKeysMonotonic (\x -> if x `elem` [1,2] then 2 else x) (fromList [(1, "a"), (2, "b"), (3, "c")])) == False
```

The docs do hint at this in "This means that @f@ maps distinct original keys to distinct resulting keys."

Since "Monotonic" was apparently chosen distinctly from "Ascending" (used elsewhere), I feel it's a misleading name to begin with. However, it's even more misleading in this library since non-injectivity would imply `Semigroup` on the values, but the type doesn't demand it. Another name I toyed with was `mapKeysIncreasing`. Please provide feedback.