### PR TITLE
Adapt to `these` splitting, and add SemialignWithIndex instances.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Monoidal containers
 
+# Next
+
+  * Support `these` 1.0.1.
+  * Add `SemialignWithIndex` instances.
+
 # 0.5.0.0
 
   * Added Data.IntMap.Monoidal and Data.IntMap.Monoidal.Strict, corresponding to Data.IntMap and Data.IntMap.Strict

--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -49,7 +49,9 @@ library
                        hashable >= 1.2 && < 1.3,
                        lens >=4.4 && <5,
                        newtype >=0.2 && <0.3,
+                       semialign >= 1 && < 1.1,
+                       semialign-indexed >= 1 && < 1.1,
                        semigroups >= 0.18 && < 0.19,
-                       these <= 0.8.1
+                       these >= 1.0.1 && < 1.1
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -59,6 +59,7 @@ import Data.Hashable.Lifted (Hashable1)
 import Control.Lens
 import Control.Newtype
 import Data.Align
+import Data.Semialign.Indexed
 
 -- | A 'HashMap' with monoidal accumulation
 newtype MonoidalHashMap k a = MonoidalHashMap { getMonoidalHashMap :: M.HashMap k a }
@@ -67,9 +68,7 @@ newtype MonoidalHashMap k a = MonoidalHashMap { getMonoidalHashMap :: M.HashMap 
 #if MIN_VERSION_unordered_containers(0,2,8)
              , Hashable1
 #endif
-#if MIN_VERSION_these(0,8,0)
              , Semialign
-#endif
              )
 
 type instance Index (MonoidalHashMap k a) = k
@@ -94,6 +93,8 @@ instance (Eq k, Hashable k) => FoldableWithIndex k (MonoidalHashMap k)
 instance (Eq k, Hashable k) => TraversableWithIndex k (MonoidalHashMap k) where
     itraverse f (MonoidalHashMap m) = fmap MonoidalHashMap $ itraverse f m
     {-# INLINE itraverse #-}
+
+instance (Eq k, Hashable k) => SemialignWithIndex k (MonoidalHashMap k)
 
 instance AsEmpty (MonoidalHashMap k a) where
     _Empty = nearly (MonoidalHashMap M.empty) (M.null . unpack)

--- a/src/Data/IntMap/Monoidal.hs
+++ b/src/Data/IntMap/Monoidal.hs
@@ -151,16 +151,15 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+import Data.Semialign.Indexed
 
 -- | An 'IntMap' with monoidal accumulation
 newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
     deriving (Show, Read, Functor, Eq, Ord, NFData,
               Foldable, Traversable,
               FromJSON, ToJSON, FromJSON1, ToJSON1,
-              Data, Typeable, Align
-#if MIN_VERSION_these(0,8,0)
-             , Semialign
-#endif
+              Data, Typeable, Align,
+              Semialign
              )
 
 #if MIN_VERSION_containers(0,5,9)
@@ -191,6 +190,8 @@ instance FoldableWithIndex Int MonoidalIntMap
 instance TraversableWithIndex Int MonoidalIntMap where
     itraverse f (MonoidalIntMap m) = fmap MonoidalIntMap $ itraverse f m
     {-# INLINE itraverse #-}
+
+instance SemialignWithIndex Int MonoidalIntMap
 
 instance TraverseMin Int MonoidalIntMap  where
     traverseMin f (MonoidalIntMap m) = fmap MonoidalIntMap $ traverseMin f m

--- a/src/Data/IntMap/Monoidal/Strict.hs
+++ b/src/Data/IntMap/Monoidal/Strict.hs
@@ -151,16 +151,15 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+import Data.Semialign.Indexed
 
 -- | An 'IntMap' with monoidal accumulation
 newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
     deriving (Show, Read, Functor, Eq, Ord, NFData,
               Foldable, Traversable,
               FromJSON, ToJSON, FromJSON1, ToJSON1,
-              Data, Typeable, Align
-#if MIN_VERSION_these(0,8,0)
-              , Semialign
-#endif
+              Data, Typeable, Align,
+              Semialign
              )
 
 #if MIN_VERSION_containers(0,5,9)
@@ -191,6 +190,8 @@ instance FoldableWithIndex Int MonoidalIntMap
 instance TraversableWithIndex Int MonoidalIntMap where
     itraverse f (MonoidalIntMap m) = fmap MonoidalIntMap $ itraverse f m
     {-# INLINE itraverse #-}
+
+instance SemialignWithIndex Int MonoidalIntMap
 
 instance TraverseMin Int MonoidalIntMap  where
     traverseMin f (MonoidalIntMap m) = fmap MonoidalIntMap $ traverseMin f m

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -151,6 +151,7 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+import Data.Semialign.Indexed
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
@@ -158,9 +159,7 @@ newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
              , Foldable, Traversable
              , FromJSON, ToJSON, FromJSON1, ToJSON1
              , Data, Typeable, Align
-#if MIN_VERSION_these(0,8,0)
              , Semialign
-#endif
              )
 
 #if MIN_VERSION_containers(0,5,9)
@@ -191,6 +190,8 @@ instance FoldableWithIndex k (MonoidalMap k)
 instance TraversableWithIndex k (MonoidalMap k) where
     itraverse f (MonoidalMap m) = fmap MonoidalMap $ itraverse f m
     {-# INLINE itraverse #-}
+
+instance (Ord k) => SemialignWithIndex k (MonoidalMap k)
 
 instance Ord k => TraverseMin k (MonoidalMap k) where
     traverseMin f (MonoidalMap m) = fmap MonoidalMap $ traverseMin f m

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -151,6 +151,7 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+import Data.Semialign.Indexed
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
@@ -158,9 +159,7 @@ newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
              , Foldable, Traversable
              , FromJSON, ToJSON, FromJSON1, ToJSON1
              , Data, Typeable, Align
-#if MIN_VERSION_these(0,8,0)
              , Semialign
-#endif
              )
 
 #if MIN_VERSION_containers(0,5,9)
@@ -191,6 +190,8 @@ instance FoldableWithIndex k (MonoidalMap k)
 instance TraversableWithIndex k (MonoidalMap k) where
     itraverse f (MonoidalMap m) = fmap MonoidalMap $ itraverse f m
     {-# INLINE itraverse #-}
+
+instance (Ord k) => SemialignWithIndex k (MonoidalMap k)
 
 instance Ord k => TraverseMin k (MonoidalMap k) where
     traverseMin f (MonoidalMap m) = fmap MonoidalMap $ traverseMin f m


### PR DESCRIPTION
Rather than a complicated set of flags and CPP, I elected to simplify
and to just bump the dependency, without attempting to maintain
compatibility with prior versions of `these`.