### PR TITLE
Make functions correspond more closely to Data.Map behavior

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Monoidal containers
 
+# 0.6
+
+  * Deprecates 0.5.* and reverts behavior of fromList, insert, mapKeys, etc. to match behavior in Data.Map. The only difference in behavior between Data.Map.Monoidal.MonoidalMap and Data.Map.Map is now the semigroup and monoid instances (as was the case in 0.4 and earlier).
+  * Fix the argument order of Data.HashMap.Monoidal.insert
+  * Remove Data.HashMap.Monoidal.insertOrReplace as it is now identical to Data.HashMap.Monoidal.insert
+  * Added Data.HashMap.Monoidal.insertWith and Data.HashMap.Monoidal.fromListWith
+
 # 0.5.0.1
 
   * Add a flag, `split-these`, to select whether to use the new "these"/"semialign" packages or the older combined "these" package.

--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -1,5 +1,5 @@
 name:                monoidal-containers
-version:             0.5.0.1
+version:             0.6
 synopsis:            Containers with monoidal accumulation
 description:
     Containers with merging via monoidal accumulation. The 'Monoid' instances

--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -20,6 +20,7 @@ module Data.HashMap.Monoidal
       -- * Often-needed functions
     , toList
     , fromList
+    , fromListWith
     , singleton
     , size
     , member
@@ -31,7 +32,7 @@ module Data.HashMap.Monoidal
     , delete
     , mapKeys
     , insert
-    , insertOrReplace
+    , insertWith
     , modify
     , modifyDef
     , map
@@ -125,7 +126,7 @@ instance Newtype (MonoidalHashMap k a) (M.HashMap k a) where
 #if MIN_VERSION_base(4,7,0)
 instance (Eq k, Hashable k, Semigroup a) => Exts.IsList (MonoidalHashMap k a) where
     type Item (MonoidalHashMap k a) = (k, a)
-    fromList = MonoidalHashMap . M.fromListWith (<>)
+    fromList = MonoidalHashMap . M.fromList
     {-# INLINE fromList #-}
     toList = M.toList . unpack
     {-# INLINE toList #-}
@@ -182,10 +183,17 @@ keys = M.keys . unpack
 {-# INLINE keys #-}
 
 -- | /O(n*log n)/. Construct a map with the supplied mappings. If the list
--- contains duplicate mappings, values will be merged using (mappend newVal oldVal).
-fromList :: (Eq k, Hashable k, Semigroup a) => [(k,a)] -> MonoidalHashMap k a
-fromList = pack . M.fromListWith (<>)
+-- contains duplicate mappings, values will be replaced.
+fromList :: (Eq k, Hashable k) => [(k,a)] -> MonoidalHashMap k a
+fromList = pack . M.fromList
 {-# INLINE fromList #-}
+
+-- | /O(n*log n)/. Construct a map with the supplied mappings. If the list
+-- contains duplicate mappings, values will be merged using the provided combining function.
+fromListWith :: (Eq k, Hashable k) => (a -> a -> a) -> [(k,a)] -> MonoidalHashMap k a
+fromListWith f = pack . M.fromListWith f
+{-# INLINE fromListWith #-}
+
 
 -- | /O(n*log n)/.  Return a list of this map's elements. The list is produced
 -- lazily. The order of its elements is unspecified.
@@ -193,27 +201,26 @@ toList :: MonoidalHashMap k a -> [(k,a)]
 toList = M.toList . unpack
 {-# INLINE toList #-}
 
--- | /O(log n)/. Insert a value on some key, if it exists -- mappend
--- to the existing one.
-insert :: (Semigroup a, Hashable k, Eq k)
-       => a
-       -> k
+-- | /O(log n)/. Insert a value on some key, if it exists replace the value.
+insert :: (Hashable k, Eq k)
+       => k
+       -> a
        -> MonoidalHashMap k a
        -> MonoidalHashMap k a
-insert x k = pack
-           . M.insertWith (<>) k x
+insert k x = pack
+           . M.insert k x
            . unpack
 
--- | /O(log n)/. Insert a value on some key with a function, if value
--- under key exists -- replace it.
-insertOrReplace :: (Semigroup a, Hashable k, Eq k)
-                => a
-                -> k
-                -> MonoidalHashMap k a
-                -> MonoidalHashMap k a
-insertOrReplace x k = pack
-                    . M.insert k x
-                    . unpack
+-- | /O(log n)/. Insert a value on some key, if it exists apply the combining function.
+insertWith :: (Hashable k, Eq k)
+       => (a -> a -> a)
+       -> k
+       -> a
+       -> MonoidalHashMap k a
+       -> MonoidalHashMap k a
+insertWith f k x = pack
+           . M.insertWith f k x
+           . unpack
 
 -- | /O(log n)/. Modify a value on some key with a function, if value
 -- under key doesn't exist -- use mempty.
@@ -228,7 +235,7 @@ modify f k = pack
 
 -- | /O(log n)/. Modify a value on some key with a function, providing
 -- a default value if that key doesn't exist.
-modifyDef :: (Semigroup a, Hashable k, Eq k)
+modifyDef :: (Hashable k, Eq k)
           => a -> (a -> a)
           -> k -> MonoidalHashMap k a
           -> MonoidalHashMap k a
@@ -239,7 +246,7 @@ modifyDef d f k = pack
 
 -- | /O(n)/. Map a function to each key of a map, if it will result
 -- in duplicated mappings, their values will be merged in unspecified order
-mapKeys :: (Semigroup a, Hashable k, Eq k, Hashable k', Eq k')
+mapKeys :: (Hashable k, Eq k, Hashable k', Eq k')
         => (k -> k') -> MonoidalHashMap k a -> MonoidalHashMap k' a
 mapKeys f = fromList
           . fmap (\(k, v) -> (f k, v))

--- a/src/Data/IntMap/Monoidal.hs
+++ b/src/Data/IntMap/Monoidal.hs
@@ -321,8 +321,8 @@ empty :: forall a. MonoidalIntMap a
 empty = coerce (M.empty :: M.IntMap a)
 {-# INLINE empty #-}
 
-insert :: forall a. Semigroup a => Int -> a -> MonoidalIntMap a -> MonoidalIntMap a
-insert = coerce (M.insertWith (<>) :: Int -> a -> M.IntMap a -> M.IntMap a)
+insert :: forall a. Int -> a -> MonoidalIntMap a -> MonoidalIntMap a
+insert = coerce (M.insert :: Int -> a -> M.IntMap a -> M.IntMap a)
 {-# INLINE insert #-}
 
 insertWith :: forall a. (a -> a -> a) -> Int -> a -> MonoidalIntMap a -> MonoidalIntMap a
@@ -421,8 +421,8 @@ mapAccumRWithKey :: forall a b c. (a -> Int -> b -> (a, c)) -> a -> MonoidalIntM
 mapAccumRWithKey = coerce (M.mapAccumRWithKey :: (a -> Int -> b -> (a, c)) -> a -> M.IntMap b -> (a, M.IntMap c))
 {-# INLINE mapAccumRWithKey #-}
 
-mapKeys :: forall a. Semigroup a => (Int -> Int) -> MonoidalIntMap a -> MonoidalIntMap a
-mapKeys = coerce (M.mapKeysWith (<>) :: (Int -> Int) -> M.IntMap a -> M.IntMap a)
+mapKeys :: forall a. (Int -> Int) -> MonoidalIntMap a -> MonoidalIntMap a
+mapKeys = coerce (M.mapKeys :: (Int -> Int) -> M.IntMap a -> M.IntMap a)
 {-# INLINE mapKeys #-}
 
 mapKeysWith :: forall a. (a -> a -> a) -> (Int -> Int) -> MonoidalIntMap a -> MonoidalIntMap a
@@ -481,8 +481,8 @@ toList :: forall a. MonoidalIntMap a -> [(Int, a)]
 toList = coerce (M.toList :: M.IntMap a -> [(Int, a)])
 {-# INLINE toList #-}
 
-fromList :: forall a. Semigroup a => [(Int, a)] -> MonoidalIntMap a
-fromList = fromListWith (<>)
+fromList :: forall a. [(Int, a)] -> MonoidalIntMap a
+fromList = coerce (M.fromList :: [(Int, a)] -> M.IntMap a)
 {-# INLINE fromList #-}
 
 fromListWith :: forall a. (a -> a -> a) -> [(Int, a)] -> MonoidalIntMap a
@@ -501,8 +501,8 @@ toDescList :: forall a. MonoidalIntMap a -> [(Int, a)]
 toDescList = coerce (M.toDescList :: M.IntMap a -> [(Int, a)])
 {-# INLINE toDescList #-}
 
-fromAscList :: forall a. Semigroup a => [(Int, a)] -> MonoidalIntMap a
-fromAscList = fromAscListWith (<>)
+fromAscList :: forall a. [(Int, a)] -> MonoidalIntMap a
+fromAscList = coerce (M.fromAscList :: [(Int, a)] -> M.IntMap a)
 {-# INLINE fromAscList #-}
 
 fromAscListWith :: forall a. (a -> a -> a) -> [(Int, a)] -> MonoidalIntMap a

--- a/src/Data/IntMap/Monoidal/Strict.hs
+++ b/src/Data/IntMap/Monoidal/Strict.hs
@@ -321,8 +321,8 @@ empty :: forall a. MonoidalIntMap a
 empty = coerce (M.empty :: M.IntMap a)
 {-# INLINE empty #-}
 
-insert :: forall a. Semigroup a => Int -> a -> MonoidalIntMap a -> MonoidalIntMap a
-insert = coerce (M.insertWith (<>) :: Int -> a -> M.IntMap a -> M.IntMap a)
+insert :: forall a. Int -> a -> MonoidalIntMap a -> MonoidalIntMap a
+insert = coerce (M.insert :: Int -> a -> M.IntMap a -> M.IntMap a)
 {-# INLINE insert #-}
 
 insertWith :: forall a. (a -> a -> a) -> Int -> a -> MonoidalIntMap a -> MonoidalIntMap a
@@ -421,8 +421,8 @@ mapAccumRWithKey :: forall a b c. (a -> Int -> b -> (a, c)) -> a -> MonoidalIntM
 mapAccumRWithKey = coerce (M.mapAccumRWithKey :: (a -> Int -> b -> (a, c)) -> a -> M.IntMap b -> (a, M.IntMap c))
 {-# INLINE mapAccumRWithKey #-}
 
-mapKeys :: forall a. Semigroup a => (Int -> Int) -> MonoidalIntMap a -> MonoidalIntMap a
-mapKeys = coerce (M.mapKeysWith (<>) :: (Int -> Int) -> M.IntMap a -> M.IntMap a)
+mapKeys :: forall a. (Int -> Int) -> MonoidalIntMap a -> MonoidalIntMap a
+mapKeys = coerce (M.mapKeys :: (Int -> Int) -> M.IntMap a -> M.IntMap a)
 {-# INLINE mapKeys #-}
 
 mapKeysWith :: forall a. (a -> a -> a) -> (Int -> Int) -> MonoidalIntMap a -> MonoidalIntMap a
@@ -481,8 +481,8 @@ toList :: forall a. MonoidalIntMap a -> [(Int, a)]
 toList = coerce (M.toList :: M.IntMap a -> [(Int, a)])
 {-# INLINE toList #-}
 
-fromList :: forall a. Semigroup a => [(Int, a)] -> MonoidalIntMap a
-fromList = fromListWith (<>)
+fromList :: forall a. [(Int, a)] -> MonoidalIntMap a
+fromList = coerce (M.fromList :: [(Int, a)] -> M.IntMap a)
 {-# INLINE fromList #-}
 
 fromListWith :: forall a. (a -> a -> a) -> [(Int, a)] -> MonoidalIntMap a
@@ -501,8 +501,8 @@ toDescList :: forall a. MonoidalIntMap a -> [(Int, a)]
 toDescList = coerce (M.toDescList :: M.IntMap a -> [(Int, a)])
 {-# INLINE toDescList #-}
 
-fromAscList :: forall a. Semigroup a => [(Int, a)] -> MonoidalIntMap a
-fromAscList = fromAscListWith (<>)
+fromAscList :: forall a. [(Int, a)] -> MonoidalIntMap a
+fromAscList = coerce (M.fromAscList :: [(Int, a)] -> M.IntMap a)
 {-# INLINE fromAscList #-}
 
 fromAscListWith :: forall a. (a -> a -> a) -> [(Int, a)] -> MonoidalIntMap a

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -323,8 +323,8 @@ empty :: forall k a. MonoidalMap k a
 empty = coerce (M.empty :: M.Map k a)
 {-# INLINE empty #-}
 
-insert :: forall k a. (Ord k, Semigroup a) => k -> a -> MonoidalMap k a -> MonoidalMap k a
-insert = insertWith (<>)
+insert :: forall k a. Ord k => k -> a -> MonoidalMap k a -> MonoidalMap k a
+insert = coerce (M.insert :: k -> a -> M.Map k a -> M.Map k a)
 {-# INLINE insert #-}
 
 insertWith :: forall k a. Ord k => (a -> a -> a) -> k -> a -> MonoidalMap k a -> MonoidalMap k a
@@ -423,8 +423,8 @@ mapAccumRWithKey :: forall k a b c. (a -> k -> b -> (a, c)) -> a -> MonoidalMap 
 mapAccumRWithKey = coerce (M.mapAccumRWithKey :: (a -> k -> b -> (a, c)) -> a -> M.Map k b -> (a, M.Map k c))
 {-# INLINE mapAccumRWithKey #-}
 
-mapKeys :: forall k1 k2 a. (Ord k2, Semigroup a) => (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
-mapKeys = mapKeysWith (<>)
+mapKeys :: forall k1 k2 a. Ord k2 => (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
+mapKeys = coerce (M.mapKeys :: (k1 -> k2) -> M.Map k1 a -> M.Map k2 a)
 {-# INLINE mapKeys #-}
 
 mapKeysWith :: forall k1 k2 a. Ord k2 => (a -> a -> a) -> (k1 -> k2) -> MonoidalMap k1 a -> MonoidalMap k2 a
@@ -501,8 +501,8 @@ toList :: forall k a. MonoidalMap k a -> [(k, a)]
 toList = coerce (M.toList :: M.Map k a -> [(k, a)])
 {-# INLINE toList #-}
 
-fromList :: forall k a. (Ord k, Semigroup a) => [(k, a)] -> MonoidalMap k a
-fromList = fromListWith (<>)
+fromList :: forall k a. Ord k => [(k, a)] -> MonoidalMap k a
+fromList = coerce (M.fromList :: [(k, a)] -> M.Map k a)
 {-# INLINE fromList #-}
 
 fromListWith :: forall k a. Ord k => (a -> a -> a) -> [(k, a)] -> MonoidalMap k a
@@ -521,8 +521,8 @@ toDescList :: forall k a. MonoidalMap k a -> [(k, a)]
 toDescList = coerce (M.toDescList :: M.Map k a -> [(k, a)])
 {-# INLINE toDescList #-}
 
-fromAscList :: forall k a. (Eq k, Semigroup a) => [(k, a)] -> MonoidalMap k a
-fromAscList = fromAscListWith (<>)
+fromAscList :: forall k a. Eq k => [(k, a)] -> MonoidalMap k a
+fromAscList = coerce (M.fromAscList :: [(k, a)] -> M.Map k a)
 {-# INLINE fromAscList #-}
 
 fromAscListWith :: forall k a. Eq k => (a -> a -> a) -> [(k, a)] -> MonoidalMap k a

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -322,8 +322,8 @@ empty :: forall k a. MonoidalMap k a
 empty = coerce (M.empty :: M.Map k a)
 {-# INLINE empty #-}
 
-insert :: forall k a. (Ord k, Semigroup a) => k -> a -> MonoidalMap k a -> MonoidalMap k a
-insert = insertWith (<>)
+insert :: forall k a. Ord k => k -> a -> MonoidalMap k a -> MonoidalMap k a
+insert = coerce (M.insert :: k -> a -> M.Map k a -> M.Map k a)
 {-# INLINE insert #-}
 
 insertWith :: forall k a. Ord k => (a -> a -> a) -> k -> a -> MonoidalMap k a -> MonoidalMap k a


### PR DESCRIPTION
This is a breaking change. The more "monoidal" behaviors that this
reverts could eventually be re-added as a separate module that more
thoroughly and systematically applies the monoid/semigroup operations.

The goal of Data.Map.Monoidal is to be as similar to Data.Map as
possible except for the Monoid/Semigroup instance that it replaces.

Thanks to @cgibbard and @bgamari for helping clarify this goal.