### PR TITLE
Relax semialign bound, add instances for Data.Semialign.Zip

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -58,8 +58,7 @@ library
 
   if flag(split-these)
     build-depends:     these >= 1 && <1.1,
-                       semialign >=1 && <1.1
-                    
+                       semialign >=1 && <1.2
   else
     build-depends:     these >= 0.7 && <0.9
 

--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -60,6 +60,11 @@ import Data.Hashable.Lifted (Hashable1)
 import Control.Lens
 import Control.Newtype
 import Data.Align
+#ifdef MIN_VERSION_semialign
+#if MIN_VERSION_semialign(1,0,0)
+import Data.Semialign
+#endif
+#endif
 
 -- | A 'HashMap' with monoidal accumulation
 newtype MonoidalHashMap k a = MonoidalHashMap { getMonoidalHashMap :: M.HashMap k a }
@@ -70,6 +75,12 @@ newtype MonoidalHashMap k a = MonoidalHashMap { getMonoidalHashMap :: M.HashMap 
 #endif
 #if MIN_VERSION_these(0,8,0)
              , Semialign
+#endif
+#ifdef MIN_VERSION_semialign
+             , Unalign
+#if MIN_VERSION_semialign(1,1,0)
+             , Zip
+#endif
 #endif
              )
 

--- a/src/Data/IntMap/Monoidal.hs
+++ b/src/Data/IntMap/Monoidal.hs
@@ -151,6 +151,11 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+#ifdef MIN_VERSION_semialign
+#if MIN_VERSION_semialign(1,0,0)
+import Data.Semialign
+#endif
+#endif
 
 -- | An 'IntMap' with monoidal accumulation
 newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
@@ -160,6 +165,12 @@ newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
               Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
              , Semialign
+#endif
+#ifdef MIN_VERSION_semialign
+             , Unalign
+#if MIN_VERSION_semialign(1,1,0)
+             , Zip
+#endif
 #endif
              )
 
@@ -186,7 +197,7 @@ instance At (MonoidalIntMap a) where
 
 instance Each (MonoidalIntMap a) (MonoidalIntMap b) a b
 
-instance FunctorWithIndex Int MonoidalIntMap 
+instance FunctorWithIndex Int MonoidalIntMap
 instance FoldableWithIndex Int MonoidalIntMap
 instance TraversableWithIndex Int MonoidalIntMap where
     itraverse f (MonoidalIntMap m) = fmap MonoidalIntMap $ itraverse f m
@@ -636,4 +647,3 @@ minViewWithKey = coerce (M.minViewWithKey :: M.IntMap a -> Maybe ((Int, a), M.In
 maxViewWithKey :: forall a. MonoidalIntMap a -> Maybe ((Int, a), MonoidalIntMap a)
 maxViewWithKey = coerce (M.maxViewWithKey :: M.IntMap a -> Maybe ((Int, a), M.IntMap a))
 {-# INLINE maxViewWithKey #-}
-

--- a/src/Data/IntMap/Monoidal/Strict.hs
+++ b/src/Data/IntMap/Monoidal/Strict.hs
@@ -151,6 +151,11 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+#ifdef MIN_VERSION_semialign
+#if MIN_VERSION_semialign(1,0,0)
+import Data.Semialign
+#endif
+#endif
 
 -- | An 'IntMap' with monoidal accumulation
 newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
@@ -159,7 +164,13 @@ newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
               FromJSON, ToJSON, FromJSON1, ToJSON1,
               Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
-              , Semialign
+             , Semialign
+#endif
+#ifdef MIN_VERSION_semialign
+             , Unalign
+#if MIN_VERSION_semialign(1,1,0)
+             , Zip
+#endif
 #endif
              )
 
@@ -186,7 +197,7 @@ instance At (MonoidalIntMap a) where
 
 instance Each (MonoidalIntMap a) (MonoidalIntMap b) a b
 
-instance FunctorWithIndex Int MonoidalIntMap 
+instance FunctorWithIndex Int MonoidalIntMap
 instance FoldableWithIndex Int MonoidalIntMap
 instance TraversableWithIndex Int MonoidalIntMap where
     itraverse f (MonoidalIntMap m) = fmap MonoidalIntMap $ itraverse f m
@@ -636,4 +647,3 @@ minViewWithKey = coerce (M.minViewWithKey :: M.IntMap a -> Maybe ((Int, a), M.In
 maxViewWithKey :: forall a. MonoidalIntMap a -> Maybe ((Int, a), MonoidalIntMap a)
 maxViewWithKey = coerce (M.maxViewWithKey :: M.IntMap a -> Maybe ((Int, a), M.IntMap a))
 {-# INLINE maxViewWithKey #-}
-

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -151,6 +151,11 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+#ifdef MIN_VERSION_semialign
+#if MIN_VERSION_semialign(1,0,0)
+import Data.Semialign
+#endif
+#endif
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
@@ -160,6 +165,12 @@ newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
              , Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
              , Semialign
+#endif
+#ifdef MIN_VERSION_semialign
+             , Unalign
+#if MIN_VERSION_semialign(1,1,0)
+             , Zip
+#endif
 #endif
              )
 
@@ -688,5 +699,3 @@ maxViewWithKey = coerce (M.maxViewWithKey :: M.Map k a -> Maybe ((k, a), M.Map k
 valid :: forall k a. Ord k => MonoidalMap k a -> Bool
 valid = coerce (M.valid :: Ord k => M.Map k a -> Bool)
 {-# INLINE valid #-}
-
-

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -151,6 +151,11 @@ import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
 import Data.Functor.Classes
 #endif
 import Data.Align
+#ifdef MIN_VERSION_semialign
+#if MIN_VERSION_semialign(1,0,0)
+import Data.Semialign
+#endif
+#endif
 
 -- | A 'Map' with monoidal accumulation
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
@@ -160,6 +165,12 @@ newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
              , Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
              , Semialign
+#endif
+#ifdef MIN_VERSION_semialign
+             , Unalign
+#if MIN_VERSION_semialign(1,1,0)
+             , Zip
+#endif
 #endif
              )
 
@@ -687,5 +698,3 @@ maxViewWithKey = coerce (M.maxViewWithKey :: M.Map k a -> Maybe ((k, a), M.Map k
 valid :: forall k a. Ord k => MonoidalMap k a -> Bool
 valid = coerce (M.valid :: Ord k => M.Map k a -> Bool)
 {-# INLINE valid #-}
-
-


### PR DESCRIPTION
New version of `semialign` came out, which splits the `zip` functions out of `Semialign` into a new `class Semialign f => Zip f`, so I added CPP to derive them.

The nested `#if`s seem to be necessary to stop CPP errors if `semialign` isn't used (i.e., flag `-split-these`).

I have tested the build with `semialign-1.1`, `semialign-1` and `-f-split-these`/`these-0.8.1`.