### PR TITLE
feat: consider aeson optional

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -30,6 +30,10 @@ source-repository head
   type:                git
   location:            git://github.com/bgamari/monoidal-containers
 
+flag aeson
+  description: Use aeson package
+  manual:      False
+  default:     True
 flag split-these
   description: Use split these/semialign packages
   manual:      False
@@ -47,7 +51,6 @@ library
                        DeriveTraversable,
                        DeriveDataTypeable
   build-depends:       base >=4.7 && <4.14,
-                       aeson >=1.0 && <1.5,
                        containers >=0.5 && <0.7,
                        deepseq >=1.3 && <1.5,
                        unordered-containers >= 0.2 && < 0.3,
@@ -65,3 +68,6 @@ library
 
   hs-source-dirs:      src
   default-language:    Haskell2010
+
+  if flag(aeson)
+    build-depends:     aeson >=1.0 && <1.5

--- a/src/Data/IntMap/Monoidal.hs
+++ b/src/Data/IntMap/Monoidal.hs
@@ -146,7 +146,9 @@ import Control.DeepSeq
 import qualified Data.IntMap as M
 import Control.Lens
 import Control.Newtype
+#ifdef MIN_VERSION_aeson
 import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
+#endif
 #if MIN_VERSION_containers(0,5,9)
 import Data.Functor.Classes
 #endif
@@ -161,7 +163,9 @@ import Data.Zip (Zip)
 newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
     deriving (Show, Read, Functor, Eq, Ord, NFData,
               Foldable, Traversable,
+#ifdef MIN_VERSION_aeson
               FromJSON, ToJSON, FromJSON1, ToJSON1,
+#endif
               Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
              , Semialign

--- a/src/Data/IntMap/Monoidal/Strict.hs
+++ b/src/Data/IntMap/Monoidal/Strict.hs
@@ -146,7 +146,9 @@ import Control.DeepSeq
 import qualified Data.IntMap.Strict as M
 import Control.Lens
 import Control.Newtype
+#ifdef MIN_VERSION_aeson
 import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
+#endif
 #if MIN_VERSION_containers(0,5,9)
 import Data.Functor.Classes
 #endif
@@ -161,7 +163,9 @@ import Data.Zip (Zip)
 newtype MonoidalIntMap a = MonoidalIntMap { getMonoidalIntMap :: M.IntMap a }
     deriving (Show, Read, Functor, Eq, Ord, NFData,
               Foldable, Traversable,
+#ifdef MIN_VERSION_aeson
               FromJSON, ToJSON, FromJSON1, ToJSON1,
+#endif
               Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
               , Semialign

--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -146,7 +146,9 @@ import Control.DeepSeq
 import qualified Data.Map as M
 import Control.Lens
 import Control.Newtype
+#ifdef MIN_VERSION_aeson
 import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
+#endif
 #if MIN_VERSION_containers(0,5,9)
 import Data.Functor.Classes
 #endif
@@ -161,7 +163,9 @@ import Data.Zip (Zip)
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
     deriving ( Show, Read, Functor, Eq, Ord, NFData
              , Foldable, Traversable
+#ifdef AESON
              , FromJSON, ToJSON, FromJSON1, ToJSON1
+#endif
              , Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
              , Semialign

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -146,7 +146,9 @@ import Control.DeepSeq
 import qualified Data.Map.Strict as M
 import Control.Lens
 import Control.Newtype
+#ifdef MIN_VERSION_aeson
 import Data.Aeson(FromJSON, ToJSON, FromJSON1, ToJSON1)
+#endif
 #if MIN_VERSION_containers(0,5,9)
 import Data.Functor.Classes
 #endif
@@ -161,7 +163,9 @@ import Data.Zip (Zip)
 newtype MonoidalMap k a = MonoidalMap { getMonoidalMap :: M.Map k a }
     deriving ( Show, Read, Functor, Eq, Ord, NFData
              , Foldable, Traversable
+#ifdef AESON
              , FromJSON, ToJSON, FromJSON1, ToJSON1
+#endif
              , Data, Typeable, Align
 #if MIN_VERSION_these(0,8,0)
              , Semialign


### PR DESCRIPTION
Adds the option to include / remove the Aeson typeclasses and dependency introduced by #21 with the `aeson` flag. For forward compatibility, the flag is on by default.

The flag was introduced as a personal project of mine uses the monoidal-containers library but has no use for aeson. Still, the aeson library seemed to add 12 Mb of code in the final executable (6 Mb when stripped), despite section splitting.