### PR TITLE
Relax upper bound on `these`

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -57,9 +57,9 @@ library
                        semigroups >= 0.18 && < 0.20
 
   if flag(split-these)
-    build-depends:     these >= 1 && <1.1,
+    build-depends:     these >= 1 && <1.2,
                        semialign >=1 && <1.2
-                    
+
   else
     build-depends:     these >= 0.7 && <0.9
 


### PR DESCRIPTION
I used the following `shell.nix` to build an environment with `these-1.1.1.1` and successfully built `monoidal-containers`:

```nix
{ nixpkgs ? import <nixpkgs> {} }:
nixpkgs.haskellPackages.developPackage {
  root = ./.;
  overrides = self: super: {
    semialign = super.callHackageDirect {
      pkg = "semialign";
      ver = "1.1.0.1";
      sha256 = "1xs5dvz87gx6xnannw6bc70nzr8ffhk0j6n7n0p5dqair9sz77x4";
    } {};
    these = super.callHackageDirect {
      pkg = "these";
      ver = "1.1.1.1";
      sha256 = "1i1nfh41vflvqxi8w8n2s35ymx2z9119dg5zmd2r23ya7vwvaka1";
    } {};
  };
}
```

It would be neat to get a metadata revision after merge, because `these-1.1.1.1` has started appearing in stackage snapshots.