### PR TITLE
bump `aeson`, `semialign` upper bounds

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -47,7 +47,7 @@ library
                        DeriveTraversable,
                        DeriveDataTypeable
   build-depends:       base >=4.7 && <4.16,
-                       aeson >=1.0 && <1.6,
+                       aeson >=1.0 && <2.1,
                        containers >=0.5 && <0.7,
                        deepseq >=1.3 && <1.5,
                        unordered-containers >= 0.2 && < 0.3,
@@ -58,7 +58,7 @@ library
 
   if flag(split-these)
     build-depends:     these >= 1 && <1.2,
-                       semialign >=1 && <1.2
+                       semialign >=1 && <1.3
   else
     build-depends:     these >= 0.7 && <0.9
 


### PR DESCRIPTION
`cabal build all` succeeds 
```
% cabal build all
Up to date
```

with `cabal.project`
```
packages:
  .
        
constraints:
    semialign ==1.2.*
  , aeson >=2.0.1.0
```