### PR TITLE
Bump lens and hashable version bounds

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -1,5 +1,5 @@
 name:               monoidal-containers
-version:            0.6.1.0
+version:            0.6.1.1
 synopsis:           Containers with monoidal accumulation
 description:
   Containers with merging via monoidal accumulation. The 'Monoid' instances
@@ -57,8 +57,8 @@ library
     , base                  >=4.7   && <4.16
     , containers            >=0.5.9 && <0.7
     , deepseq               >=1.3   && <1.5
-    , hashable              >=1.2   && <1.4
-    , lens                  >=4.4   && <5.1
+    , hashable              >=1.2   && <1.5
+    , lens                  >=4.4   && <5.2
     , newtype               >=0.2   && <0.3
     , unordered-containers  >=0.2   && <0.3
     , witherable            >=0.4   && <0.5

--- a/src/Data/HashMap/Monoidal.hs
+++ b/src/Data/HashMap/Monoidal.hs
@@ -51,6 +51,10 @@ import Data.Typeable (Typeable)
 import qualified GHC.Exts as Exts
 #endif
 
+#if MIN_VERSION_base(4,9,0)
+import Data.Functor.Classes (Eq1)
+#endif
+
 import Control.DeepSeq
 import qualified Data.HashMap.Strict as M
 import Data.Hashable (Hashable)
@@ -72,6 +76,9 @@ import qualified Witherable
 newtype MonoidalHashMap k a = MonoidalHashMap { getMonoidalHashMap :: M.HashMap k a }
     deriving ( Show, Read, Functor, Eq, NFData
              , Foldable, Traversable, Data, Typeable, Hashable, Align
+#if MIN_VERSION_base(4,9,0)
+             , Eq1
+#endif
 #if MIN_VERSION_unordered_containers(0,2,8)
              , Hashable1
 #endif


### PR DESCRIPTION
as of hashable-1.4.0.0, Hasable1 requires Eq1. also bumped lens