### PR TITLE
remove cyclic definition of !?

### DIFF
--- a/src/Data/Map/Monoidal.hs
+++ b/src/Data/Map/Monoidal.hs
@@ -318,7 +318,7 @@ keys = M.keys . unpack
 {-# INLINE keys #-}
 
 (!?) :: forall k a. Ord k => MonoidalMap k a -> k -> Maybe a
-(!?) m k = (coerce m) !? k
+(!?) = coerce ((M.!?) :: M.Map k a -> k -> Maybe a)
 infixl 9 !?
 {-# INLINE (!?) #-}
 

--- a/src/Data/Map/Monoidal/Strict.hs
+++ b/src/Data/Map/Monoidal/Strict.hs
@@ -318,10 +318,9 @@ keys = M.keys . unpack
 {-# INLINE keys #-}
 
 (!?) :: forall k a. Ord k => MonoidalMap k a -> k -> Maybe a
-(!?) m k = (coerce m) !? k
+(!?) = coerce ((M.!?) :: M.Map k a -> k -> Maybe a)
 infixl 9 !?
 {-# INLINE (!?) #-}
-
 
 (!) :: forall k a. Ord k => MonoidalMap k a -> k -> a
 (!) = coerce ((M.!) :: M.Map k a -> k -> a)


### PR DESCRIPTION
`(!?)` does not follow the pattern elsewhere in `Data.Map.Monoidal(|Strict)` of coercing the function instead of the map. It is also defined in terms of itself, NOT the version from `Data.Map`:

```hs
(!?) :: forall k a. Ord k => MonoidalMap k a -> k -> Maybe a
(!?) m k = (coerce m) !? k
infixl 9 !?
{-# INLINE (!?) #-}
```

This results in infinite loops when `(!?)` is used over `(!)`:

```hs
*Data.Map.Monoidal> let m = singleton 4 5
*Data.Map.Monoidal> m
MonoidalMap {getMonoidalMap = fromList [(4,5)]}
*Data.Map.Monoidal> m !? 4
<<loop>>
```

This PR addresses this in both locations.