### PR TITLE
ghc92-base417 extend base < 4.18

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -54,7 +54,7 @@ library
 
   build-depends:
       aeson                 >=1.0   && <2.1
-    , base                  >=4.7   && <4.16
+    , base                  >=4.7   && <4.18
     , containers            >=0.5.9 && <0.7
     , deepseq               >=1.3   && <1.5
     , hashable              >=1.2   && <1.5


### PR DESCRIPTION
`monoidal-containers` dependency popped up on my dependency horizon once I added `ghc-debug` library.
I heard that ghc-debug works well with GHC92, but cabal's library file doesn't have a trace of GHC9.
Just bumping base limit appeared enough to adapt the library for GHC92.
