### PR TITLE
Allow `lens ^>=5.3`

### DIFF
--- a/monoidal-containers.cabal
+++ b/monoidal-containers.cabal
@@ -58,7 +58,7 @@ library
     , containers            >=0.5.9 && <0.8
     , deepseq               >=1.3   && <1.6
     , hashable              >=1.2   && <1.5
-    , lens                  >=4.4   && <5.3
+    , lens                  >=4.4   && <5.4
     , newtype               >=0.2   && <0.3
     , unordered-containers  >=0.2   && <0.3
     , witherable            >=0.4   && <0.5


### PR DESCRIPTION
We are successfully using `allow-newer: monoidal-containers:lens` internally, and this PR passes `cabal build --constraint 'lens ^>=5.3'`.

Can we please also have a Hackage metadata revision?